### PR TITLE
Several enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,14 +66,23 @@ vim /etc/postfix/aliases
 
 ...
 
-# notice only, not forward
+# notify only, not forward
 user: |/usr/local/bin/email2slack.py
 
-# notice and forward e-mail to another user
+# notify and forward e-mail to another user
 user: anotheruser, |/usr/local/bin/email2slack.py
 
-# notice and leave e-mail on same user
+# notify and leave e-mail on same user
 user: \user, |/usr/local/bin/email2slack.py
+
+# you can override default slack url, team and channel with command line option,
+# which replace as default=value in each section.
+# -s url / --slack url
+# -t team-name / --team team-name
+# -c channel-name / --channel channel-name
+# -f /path/to/email2slack.conf / --config /path/to/email2slack.conf
+user: "|/usr/local/bin/email2slack.py -c '@user'"
+another: "|/usr/local/bin/email2slack.py -c '#random'"
 
 ...
 

--- a/email2slack
+++ b/email2slack
@@ -2,10 +2,10 @@
 # Enumerate slack endpoints.
 #
 # Format:
-# TEAM_ALIAS = URL
+# TEAM_ALIAS=URL
 #
 # Example:
-# myteam = https://hooks.slack.com/services/FOO/BAR/FOOBAR
+# myteam=https://hooks.slack.com/services/FOO/BAR/FOOBAR
 #
 
 
@@ -13,20 +13,28 @@
 # Team convert table.
 #
 # Format:
-# TO_ADDRESS_REGEX = TEAM_ALIAS
+# TO_ADDRESS_REGEX=TEAM_ALIAS
+#
+# Matching is executed in order of declaration.
+# 'default' means '.*', you can override with -t / --team option
 #
 # Example:
-# .* = myteam
-# .*@gmail.com = home
+# .*@gmail.com=home
+# default=myteam
 
 
 [Channel]
 # Channel convert table.
 #
 # Format:
-# TO_ADDRESS_REGEX = CHANNEL
+# TO_ADDRESS_REGEX=CHANNEL
+#
+# Matching is executed in order of declaration.
+# 'default' means '.*', you can override with -c / --channel option
+# You should not insert space after '=', or '#' is treated as comment
+
 #
 # Example:
-# .* = random
-# .*@gmail.com = general
+# .*@gmail.com=#general
+# default=#random
 

--- a/email2slack
+++ b/email2slack
@@ -38,3 +38,23 @@
 # .*@gmail.com=#general
 # default=#random
 
+
+[Flags]
+# pretext:
+#     treat mail body as pre-formatted, fixed-width text, in short ```body```
+#
+#pretext=false
+
+[MIME Part]
+# Prefer html part in multipart/alternative if mail come from this address.
+#
+# Format:
+# FROM_ADDRESS_REGEX=html
+#
+# Matching is executed in order of declaration.
+#
+
+#
+# Example:
+# foo@gmail.com=html
+#

--- a/email2slack.py
+++ b/email2slack.py
@@ -88,7 +88,7 @@ class EmailParser(object):
                 messages.append(extracted)
 
         for m in messages:
-            content_type = m[0]
+            content_type = m[0].lower()
             body = m[1].replace('\r\n', '\n')
             try:
                 parameter = dict([x.split('=', 1) for x in content_type.split('; ')[1:]])

--- a/email2slack.py
+++ b/email2slack.py
@@ -349,7 +349,7 @@ class Slack(object):
                     - len(html_escape(heading)) \
                     - increment_of_mailaddr(heading) \
                     - len('``````\n')
-        self.__post(url[0], self.__payload(text, channel=channel[0], footer='Posted by email2slack. Original mail is {:s}.'.format(html_escape(message_id))))
+        self.__post(url[0], self.__payload('', channel=channel[0], footer='Posted by email2slack. Original mail is {:s}.'.format(html_escape(message_id))))
 
     @staticmethod
     def __payload(text, username=None, channel=None, footer=None):

--- a/email2slack.py
+++ b/email2slack.py
@@ -11,7 +11,6 @@ import chardet
 import requests
 
 from bs4 import BeautifulSoup
-import json
 
 # ToDo: add doc strings
 
@@ -129,7 +128,6 @@ class Slack(object):
     @staticmethod
     def __post(url, body):
         requests.post(url, json=body)
-        #print(json.dumps(body, ensure_ascii=False, indent=2))
 
 
 def main():

--- a/email2slack.py
+++ b/email2slack.py
@@ -134,7 +134,7 @@ def main():
     raw_mail = bytearray()
     # each mail part may have a different charset from others.
     while True:
-        chunk = os.read(sys.stdin.fileno(), 32768)
+        chunk = sys.stdin.buffer.read()
         if chunk:
             raw_mail.extend(chunk)
         else:

--- a/email2slack.py
+++ b/email2slack.py
@@ -12,11 +12,12 @@ try:
 except:
     BytesParser = None
 from email.parser import Parser
+from email.utils import parseaddr
 
 import chardet
 import requests
 
-from bs4 import BeautifulSoup
+from bs4 import BeautifulSoup, Comment
 
 # ToDo: add doc strings
 
@@ -32,79 +33,93 @@ class EmailParser(object):
             'From': None,
             'To': None,
             'Subject': None,
+            'Date': None,
             'body-plain': None,
             'body-html': None
         }
-	try:
-            result['From'] = EmailParser.parse_header(parsed_mail, 'From')
-	except TypeError:
-	    result['From'] = ''
-	try:
-            result['To'] = EmailParser.parse_header(parsed_mail, 'To')
-	except TypeError:
-            result['To'] = ''
-	try:
-            result['Subject'] = EmailParser.parse_header(parsed_mail, 'Subject')
-	except TypeError:
-            result['Subject'] = ''
+        result['From'] = EmailParser.parse_header(parsed_mail, 'From')
+        result['To'] = EmailParser.parse_header(parsed_mail, 'To')
+        result['Subject'] = EmailParser.parse_header(parsed_mail, 'Subject')
+        result['Date'] = EmailParser.parse_header(parsed_mail, 'Date')
 
         messages = []
-        if parsed_mail.is_multipart():
-            for m in parsed_mail.get_payload():
-                extracted = EmailParser.extract_message(m)
-                if extracted:
-                    messages.append(extracted)
-        else:
-            extracted = EmailParser.extract_message(parsed_mail)
-            if extracted:
-                messages.append(extracted)
+        extracted = EmailParser.extract_message(parsed_mail)
+        if extracted:
+             if isinstance(extracted, list):
+                 messages.extend(extracted)
+             else:
+                 messages.append(extracted)
 
         for m in messages:
             content_type = m[0]
             body = m[1].replace('\r\n', '\n').rstrip()
 
             if content_type is None or content_type.startswith('text/plain'):
-                result['body-plain'] = body
+                if result['body-plain']:
+                    result['body-plain'] += body
+                else:
+                    result['body-plain'] = body
             elif content_type.startswith('text/html'):
-                result['body-html'] = body
+                if result['body-html']:
+                    result['body-html'] += body
+                else:
+                    result['body-html'] = body
 
         return result
 
     @staticmethod
     def extract_message(message):
+        if message.is_multipart():
+            messages = []
+            for m in message.get_payload():
+                extracted = EmailParser.extract_message(m)
+                if extracted:
+                    if isinstance(extracted, list):
+                        messages.extend(extracted)
+                    else:
+                        messages.append(extracted)
+            return messages
+
         body = message.get_payload(decode=True)
         if not body:
             return None
         charset = chardet.detect(body)['encoding']
         if charset is None:
             charset = 'utf-8'
-	elif charset == 'ISO-2022-JP':
-	    charset = 'ISO-2022-JP-2004'
+        elif charset == 'ISO-2022-JP':
+            charset = 'ISO-2022-JP-2004'
             return message['Content-Type'], body.replace(b'\033$B', b'\033$(Q').decode(encoding=charset, errors='replace')
-	elif charset == 'SJIS':
-	    charset = 'CP932'
-	elif charset == 'EUC-JP':
-	    charset = 'EUCJIS2004'
+        elif charset == 'SJIS':
+            charset = 'CP932'
+        elif charset == 'EUC-JP':
+            charset = 'EUCJIS2004'
 
         return message['Content-Type'], body.decode(encoding=charset, errors='replace')
 
     @staticmethod
     def parse_header(parsed_mail, field):
         # type: (List[str], str) -> str
-	if not parsed_mail.has_key(field):
-	    return ''
         decoded = []
-        raw_header = parsed_mail[field]
+        raw_header = parsed_mail.get(field, '')
         # decode_header does not work well in some case,
         # eg. FW: =?ISO-2022-JP?B?GyRCR1s/LklURz0bKEI=?=: 
         for chunk in re.split(r'(=\?[^?]+\?[BQ]\?[^?]+\?=)', raw_header):
             if chunk.find('=?') >= 0:
                 for decoded_chunk, charset in decode_header(chunk):
                     if charset:
+                        if charset == 'ISO-2022-JP':
+                            charset = 'ISO-2022-JP-2004'
+                            decoded_chunk = decoded_chunk.replace(b'\033$B', b'\033$(Q')
+                        elif charset == 'SJIS':
+                            charset = 'CP932'
+                        elif charset == 'EUC-JP':
+                            charset = 'EUCJIS2004'
                         try:
-                            decoded_chunk = decoded_chunk.decode(charset)
+                            decoded_chunk = decoded_chunk.decode(charset, errors='replace')
                         except TypeError:
                             pass
+                    else:
+                        decoded_chunk = decoded_chunk.decode()
                     decoded.append(decoded_chunk)
             elif chunk:
                 decoded.append(chunk)
@@ -127,36 +142,105 @@ class Slack(object):
         slack = {s[0]: s[1] for s in cfg.items('Slack')}
         self.__team = [(re.compile(t[0]), slack[t[1]]) for t in cfg.items('Team')]
         self.__channel = [(re.compile(c[0]), c[1]) for c in cfg.items('Channel')]
+        self.flags = {}
+        if cfg.has_section('Flags'):
+            self.flags['pretext'] = cfg.getboolean('Flags', 'pretext')
+        self.mime_part = {}
+        if cfg.has_section('MIME Part'):
+            self.mime_part = [(re.compile(x[0]), x[1]) for x in cfg.items('MIME Part')]
+        self.pretext = []
+        if cfg.has_section('PreText'):
+            self.pretext = [(re.compile(x[0]), x[1]) for x in cfg.items('PreText')]
 
     def notice(self, mail):
-        address_to = mail['To']
-        address_from = mail['From']
+
+        def html_escape(text):
+            return text \
+                 .replace('&', '&amp;') \
+                 .replace('<', '&lt;') \
+                 .replace('>', '&gt;')
+
+        def get_html_text(html):
+            soup = BeautifulSoup(html, "lxml")
+            for e in soup(['style', 'script', '[document]', 'head', 'title']):
+                e.extract()
+            for br in soup.find_all("br"):
+                br.replace_with("\n")
+            for td in soup.find_all("td"):
+                td.replace_with(td.get_text() + " ")
+            for tr in soup.find_all("tr"):
+                tr.replace_with(tr.get_text() + "\n")
+            for p in soup.find_all("p"):
+                p.replace_with(tr.get_text() + "\n")
+            return re.sub('\n{2,}', '\n\n', soup.get_text()).lstrip('\n')
+
+        header_to = mail['To']
+        address_to = parseaddr(header_to)[1]
+        header_from = mail['From']
+        address_from = parseaddr(header_from)[1]
         subject = mail['Subject']
-        if mail['body-plain']:
+        date = mail['Date']
+        mime_part = [x[1] for x in self.mime_part if x[0].match(address_from)]
+        if len(mime_part) and mime_part[0] == 'html' and mail['body-html']:
+            body = get_html_text(mail['body-html'])
+            self.flags['pretext'] = False
+        elif mail['body-plain']:
             body = mail['body-plain']
         elif mail['body-html']:
-            body = re.sub('\n+', '\n', BeautifulSoup(mail['body-html'], "lxml").get_text()).lstrip('\n')
-
-        text = 'From: {:s}\nTo: {:s}\nSubject: {:s}\n\n{:s}'.format(address_from, address_to, subject, body)
+            body = get_html_text(mail['body-html'])
 
         url = [r[1] for r in self.__team if r[0].match(address_to)]
         if url is None:
-            raise Exception('team not found: {:s}'.format(address_to))
+            raise Exception('team not found: {:s}'.format(header_to))
 
         channel = [r[1] for r in self.__channel if r[0].match(address_to)]
         if channel is None:
-            raise Exception('channel not found: {:s}'.format(address_to))
+            raise Exception('channel not found: {:s}'.format(header_to))
 
-        self.__post(url[0], self.__payload(text, channel=channel[0]))
+        body = html_escape(body)
+        text = html_escape('*Date*: {:s}\n*From*: {:s}\n*To*: {:s}\n*Subject*: {:s}\n'.format(date, header_from, header_to, subject))
+        msg_limit = 4000 - len(text) - 7 - 88
+        pretext = self.flags.get('pretext', False)
+        if len(body) <= msg_limit or not pretext:
+            if pretext:
+                text += '```{:s}```\n'.format(body)
+            else:
+                text += '{:s}'.format(body)
+            self.__post(url[0], self.__payload(text, channel=channel[0], footer='Posted by email2slack'))
+            return
+
+        heading = text
+        continued = 'continued: {:s}\n'.format(subject)
+        while len(body):
+            i = -1
+            if len(body) >= msg_limit:
+                i = body.rfind('\n', 0, msg_limit)
+            if i >= 0:
+                i = i + 1
+                text = '{:s}```{:s}```'.format(heading, body[0:i])
+                self.__post(url[0], self.__payload(text, channel=channel[0]))
+                body = body[i:]
+                heading = continued
+            else:
+                text = '{:s}```{:s}```'.format(heading, body)
+                self.__post(url[0], self.__payload(text, channel=channel[0]))
+                break
+        self.__post(url[0], self.__payload('', channel=channel[0], footer='Posted by email2slack'))
 
     @staticmethod
-    def __payload(text, username=None, channel=None):
+    def __payload(text, username=None, channel=None, footer=None):
         result = {'text': text}
+        attachments = None
 
         if username:
             result['username'] = username
         if channel:
             result['channel'] = channel
+        if footer:
+            if attachments is None: attachments = [{}]
+            attachments[0]["footer"] = footer
+        if attachments:
+            result['attachments'] = attachments
 
         return result
 

--- a/email2slack.py
+++ b/email2slack.py
@@ -88,7 +88,9 @@ class EmailParser(object):
                 messages.append(extracted)
 
         for m in messages:
-            content_type = m[0].lower()
+            content_type = m[0]
+            if content_type:
+                content_type = content_type.lower()
             body = m[1].replace('\r\n', '\n')
             try:
                 parameter = dict([x.split('=', 1) for x in content_type.split('; ')[1:]])

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 chardet>=2.3.0
 requests>=2.10.0
+bs4
+lxml


### PR DESCRIPTION
- case insensitive in Content-Type: header.
- loose ISO-2022-JP decode, and decode the Japanese character set using nkf if available.
- nested MIME part support.
- well unfolding on "flowed" style mail.
- supports HTML email and some html tag handling.
- well header MIME decoding.
- escape '<', '>', and '&' in Slack message, and calculate formatting markup characters size.
- add some command line options, --slack, --team, --channel and --debug.
- add pretext flag, which makes body as pre style.
