### PR TITLE
Readme improvements & corrections, and python 2 bugfix

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,14 @@ MIME E-mail forwarding script for Slack written in Python.
 
 ## Getting Started
 
+### Prerequisites
+
+Installation of email2slack requires `gcc` and the development packages of both
+`libxml2` and `libxslt`. On RedHat based systems you can install these using
+`sudo yum install gcc libxml2-devel libxslt-devel`. On Ubuntu systems you can
+install using `sudo apt-get install build-essential libxml2-dev libxslt-dev`.
+If you are using some other system there are probably similar packages available.
+
 ### Install email2slack
 
 #### From PyPI

--- a/README.md
+++ b/README.md
@@ -76,13 +76,13 @@ vim /etc/postfix/aliases
 ...
 
 # notify only, not forward
-user: |/usr/local/bin/email2slack.py
+user: |/usr/local/bin/email2slack
 
 # notify and forward e-mail to another user
-user: anotheruser, |/usr/local/bin/email2slack.py
+user: anotheruser, |/usr/local/bin/email2slack
 
 # notify and leave e-mail on same user
-user: \user, |/usr/local/bin/email2slack.py
+user: \user, |/usr/local/bin/email2slack
 
 # you can override default slack url, team and channel with command line option,
 # which replace as default=value in each section.
@@ -90,8 +90,8 @@ user: \user, |/usr/local/bin/email2slack.py
 # -t team-name / --team team-name
 # -c channel-name / --channel channel-name
 # -f /path/to/email2slack.conf / --config /path/to/email2slack.conf
-user: "|/usr/local/bin/email2slack.py -c '@user'"
-another: "|/usr/local/bin/email2slack.py -c '#random'"
+user: "|/usr/local/bin/email2slack -c '@user'"
+another: "|/usr/local/bin/email2slack -c '#random'"
 
 ...
 

--- a/email2slack/slack.py
+++ b/email2slack/slack.py
@@ -68,8 +68,8 @@ class Slack(object):
             self.__channel.append((re.compile(r'.*'), default_channel))
 
         self.flags = {}
-        if cfg.has_section('Flags'):
-            self.flags['pretext'] = cfg.getboolean('Flags', 'pretext', fallback=False)
+        if cfg.has_option('Flags', 'pretext'):
+            self.flags['pretext'] = cfg.getboolean('Flags', 'pretext')
         self.mime_part = {}
         if cfg.has_section('MIME Part'):
             self.mime_part = [(re.compile(x[0]), x[1]) for x in cfg.items('MIME Part')]


### PR DESCRIPTION
Hi,

Thanks for email2slack, it's working perfectly for us :-)

I ran into a small problem getting it working on python 2, unexpected keyword argument 'fallback' when calling `ConfigParser.getboolean()`, which I've fixed by just checking if the option exists rather than using a fallback (I _think_ still works as intended, apols if not).

Also added some info about required OS packages, gcc, libxml2, libxslt to readme, and updated the paths to the email2slack binary in the readme.

One of the Travis jobs fails, but that's due to a missing archive for python 3.3 rather than a test failure.

Mark